### PR TITLE
fix: do not fail on log lines with no depoyment

### DIFF
--- a/src/aidial_log_parser/parse_logs.py
+++ b/src/aidial_log_parser/parse_logs.py
@@ -198,7 +198,7 @@ def add_deployment_name_from_uri(batch: pa.RecordBatch) -> pa.RecordBatch:
 
 
 def filter_invalid_field(
-    batch: pa.RecordBatch, traces: pa.Array, field_name: str = DEPLOYMENT_FIELD_NAME
+    batch: pa.RecordBatch, traces: pa.Array, field_name: str
 ) -> pa.RecordBatch:
     filter_mask: pa.BooleanArray = batch[field_name].is_valid()
     if pc.all(filter_mask).as_py():  # type: ignore [reportAttributeAccessIssue]
@@ -211,7 +211,7 @@ def filter_invalid_field(
     )
     if isDebugEnabled():
         for trace in traces.filter(pc.invert(filter_mask)):  # type: ignore [reportAttributeAccessIssue]
-            logging.debug("Filtered out empty %s with trace=%s", field_name, trace)
+            logging.debug(f"Filtered out empty {field_name} with trace={trace}")
     return batch_filtered
 
 
@@ -270,8 +270,7 @@ def extract_question(request_body: str, trace: pa.StructScalar | None) -> str | 
         logging.debug("Failed to decode JSON for request.body: %s", request_body)
         # We do not want to disclose the request body in logs in non-debug mode
         logging.warning(
-            "Failed to decode request.body JSON for line with trace=%s",
-            trace,
+            f"Failed to decode request.body JSON for line with trace={trace}"
         )
         return None
     messages = request_json.get("messages", [])
@@ -307,8 +306,7 @@ def extract_answer(
         )
         # We do not want to disclose the response content in logs in non-debug mode
         logging.warning(
-            "Failed to decode assembled_response JSON for line with trace=%s",
-            trace,
+            "Failed to decode assembled_response JSON for line with trace={trace}"
         )
         return None
     choices = response_json.get("choices", [])

--- a/src/aidial_log_parser/parse_logs.py
+++ b/src/aidial_log_parser/parse_logs.py
@@ -194,24 +194,25 @@ def add_deployment_name_from_uri(batch: pa.RecordBatch) -> pa.RecordBatch:
         parse_deployment_name(r["uri"].as_py()) for r in batch["request"]
     ]
     new_batch = batch.add_column(0, DEPLOYMENT_FIELD_NAME, deployment_name)
+    return new_batch
 
-    rows_before_filter = new_batch.num_rows
-    new_batch_filtered = new_batch.filter(
-        pc.invert(new_batch[DEPLOYMENT_FIELD_NAME].is_null())  # type: ignore [reportAttributeAccessIssue]
+
+def filter_invalid_field(
+    batch: pa.RecordBatch, traces: pa.Array, field_name: str = DEPLOYMENT_FIELD_NAME
+) -> pa.RecordBatch:
+    filter_mask: pa.BooleanArray = batch[field_name].is_valid()
+    if pc.all(filter_mask).as_py():  # type: ignore [reportAttributeAccessIssue]
+        return batch
+
+    batch_filtered = batch.filter(filter_mask)
+
+    logging.warning(
+        f"Removed {batch.num_rows - batch_filtered.num_rows} rows with invalid {field_name}"
     )
-
-    bad_rows = rows_before_filter - new_batch_filtered.num_rows
-    if bad_rows:
-        logging.warning(f"Removed {bad_rows} rows with invalid {DEPLOYMENT_FIELD_NAME}")
-        if isDebugEnabled():
-            bad_uris = [
-                r["uri"].as_py()
-                for r in new_batch.filter(new_batch[DEPLOYMENT_FIELD_NAME].is_null())[
-                    "request"
-                ]
-            ]
-            logging.debug(f"Bad uris: {bad_uris}")
-    return new_batch_filtered
+    if isDebugEnabled():
+        for trace in traces.filter(pc.invert(filter_mask)):  # type: ignore [reportAttributeAccessIssue]
+            logging.debug("Filtered out empty %s with trace=%s", field_name, trace)
+    return batch_filtered
 
 
 def fill_missing_nested(column: pa.Array, target_type: pa.DataType) -> pa.StructArray:
@@ -256,6 +257,12 @@ def fill_missing(batch: pa.RecordBatch, schema: pa.Schema) -> pa.RecordBatch:
     return batch
 
 
+def get_traces_column(batch: pa.RecordBatch) -> pa.Array:
+    if "trace" in batch.column_names:
+        return batch["trace"]
+    return pa.array([None] * batch.num_rows)
+
+
 def extract_question(request_body: str, trace: pa.StructScalar | None) -> str | None:
     try:
         request_json = json.loads(request_body)
@@ -263,7 +270,8 @@ def extract_question(request_body: str, trace: pa.StructScalar | None) -> str | 
         logging.debug("Failed to decode JSON for request.body: %s", request_body)
         # We do not want to disclose the request body in logs in non-debug mode
         logging.warning(
-            "Failed to decode request.body JSON for line with trace=%s", trace
+            "Failed to decode request.body JSON for line with trace=%s",
+            trace,
         )
         return None
     messages = request_json.get("messages", [])
@@ -279,11 +287,8 @@ def extract_question(request_body: str, trace: pa.StructScalar | None) -> str | 
     return None
 
 
-def extract_questions(batch: pa.RecordBatch) -> pa.RecordBatch:
+def extract_questions(batch: pa.RecordBatch, traces: pa.Array) -> pa.RecordBatch:
     requests = batch["request"]
-    traces = (
-        batch["trace"] if "trace" in batch.column_names else [None] * batch.num_rows
-    )
     questions = [
         extract_question(r["body"].as_py(), t)
         for r, t in zip(requests, traces, strict=True)
@@ -291,12 +296,19 @@ def extract_questions(batch: pa.RecordBatch) -> pa.RecordBatch:
     return batch.append_column("question", questions)
 
 
-def extract_answer(assembled_response: str) -> str | None:
+def extract_answer(
+    assembled_response: str, trace: pa.StructScalar | None
+) -> str | None:
     try:
         response_json = json.loads(assembled_response)
     except json.JSONDecodeError:
         logging.debug(
             "Failed to decode JSON for assembled_response: %s", assembled_response
+        )
+        # We do not want to disclose the response content in logs in non-debug mode
+        logging.warning(
+            "Failed to decode assembled_response JSON for line with trace=%s",
+            trace,
         )
         return None
     choices = response_json.get("choices", [])
@@ -305,10 +317,14 @@ def extract_answer(assembled_response: str) -> str | None:
     return choices[0].get("message", {}).get("content")
 
 
-def extract_answers(batch: pa.RecordBatch) -> pa.RecordBatch:
+def extract_answers(batch: pa.RecordBatch, traces: pa.Array) -> pa.RecordBatch:
     if "assembled_response" not in batch.column_names:
         return batch
-    answers = [extract_answer(r.as_py()) for r in batch["assembled_response"]]
+    assembled_responses = batch["assembled_response"]
+    answers = [
+        extract_answer(r.as_py(), t)
+        for r, t in zip(assembled_responses, traces, strict=True)
+    ]
     return batch.append_column("answer", answers)
 
 
@@ -332,9 +348,16 @@ def process_batches(
 
         if DEPLOYMENT_FIELD_NAME not in batch.column_names:
             batch = add_deployment_name_from_uri(batch)
+
+        traces = get_traces_column(batch)
+
+        batch = filter_invalid_field(batch, traces, DEPLOYMENT_FIELD_NAME)
+
+        # Some rows may be removed by the filter, so we need to get new traces column
+        traces = get_traces_column(batch)
         batch = batch.append_column("date", [date] * batch.num_rows)
-        batch = extract_questions(batch)
-        batch = extract_answers(batch)
+        batch = extract_questions(batch, traces)
+        batch = extract_answers(batch, traces)
 
         batch = fill_missing(batch, schema)
         batch.validate(full=True)

--- a/tests/test_parse_logs.py
+++ b/tests/test_parse_logs.py
@@ -249,3 +249,109 @@ def test_parse_logs_with_incorrect_request_body():
     ]
     assert result.column("question").to_pylist() == [None]
     assert result.column("answer").to_pylist() == ["No, I cannot do that."]
+
+
+def test_parse_logs_no_deployment(caplog):
+    fs = MemoryFileSystem()
+    fs.mkdir("/logs4")
+    fs.mkdir("/parsed_logs4")
+
+    with fs.open(
+        "/logs4/date=2023-11-061699285645-11111111-2222-3333-4444-555555555555.log", "w"
+    ) as f:
+        data_route = {
+            "request": {
+                "protocol": "HTTP/1.1",
+                "method": "POST",
+                "uri": "/v1/custom_route/job",
+                "time": "2023-11-06T01:23:45.678",
+                "body": json.dumps(
+                    {
+                        "some_data": ["https://www.example.com/"],
+                    }
+                ),
+            },
+            "trace": {"trace_id": "1", "core_span_id": "1"},
+            "response": {
+                "status": 200,
+                "body": ("Job 1 started.\n\nJob 1 failed.\n\n"),
+            },
+            # No deployment name
+            "assembled_response": "{}",
+        }
+        json.dump(data_route, f)
+
+        data_completion = {
+            "request": {
+                "protocol": "HTTP/1.1",
+                "method": "POST",
+                "uri": "/openai/deployments/my_llm_app/chat/completions?api-version=2024-02-01",
+                "time": "2023-11-06T01:23:45.678",
+                "body": json.dumps(
+                    {
+                        "messages": [
+                            {
+                                "role": "user",
+                                "content": "Please sequentially count from 1 to 9999.",
+                            }
+                        ],
+                        "temperature": 1,
+                        "stream": True,
+                        "model": "my_llm_app",
+                    }
+                ),
+            },
+            "trace": {"trace_id": "2", "core_span_id": "2"},
+            "response": {
+                "status": 200,
+                "time": "2023-11-06T01:23:45.678",
+                "body": "some chunked data...",
+            },
+            "assembled_response": json.dumps(
+                {
+                    "choices": [
+                        {
+                            "message": {
+                                "role": "assistant",
+                                "content": "No, I cannot do that.",
+                            }
+                        }
+                    ]
+                }
+            ),
+        }
+        json.dump(data_completion, f)
+
+    date = pa.scalar(datetime.date(2023, 11, 6), type=pa.date32())
+    parse_logs("memory://logs4/", "memory://parsed_logs4/", date=date)
+
+    result = ds.dataset(
+        "/parsed_logs4/",
+        format="parquet",
+        partitioning=ds.partitioning(
+            schema=pa.schema(
+                [
+                    pa.field("deployment", pa.string()),
+                    pa.field("date", pa.date32()),
+                ]
+            )
+        ),
+        filesystem=fs,
+    ).to_table()
+
+    assert result.column("deployment").to_pylist() == ["my_llm_app"]
+    assert result.column("date").to_pylist() == [datetime.date(2023, 11, 6)]
+    assert result.column("assembled_response").to_pylist() == [
+        '{"choices": [{"message": {"role": "assistant", "content": "No, I cannot do that."}}]}'
+    ]
+    assert result.column("question").to_pylist() == [
+        "Please sequentially count from 1 to 9999."
+    ]
+    assert result.column("answer").to_pylist() == ["No, I cannot do that."]
+
+    # Check log messages
+    assert "Removed 1 rows with invalid deployment" in caplog.text
+    assert (
+        "Filtered out empty deployment with trace=[('trace_id', '1'), ('core_span_id', '1')]"
+        in caplog.text
+    )


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #6

### Description of changes

- `filter_invalid_field` was extracted from `add_deployment_name_from_uri` to filter the lines with no deployment names for the case if `deployment` is used from a separate field as well.
- traces column is used to report failed lines in `extract_answers` and `filter_invalid_field`, as it was in `extract_questions` before.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
