### PR TITLE
fix: do not fail if root of assembled_response is a list

### DIFF
--- a/src/aidial_log_parser/parse_logs.py
+++ b/src/aidial_log_parser/parse_logs.py
@@ -306,10 +306,16 @@ def extract_answer(
         )
         # We do not want to disclose the response content in logs in non-debug mode
         logging.warning(
-            "Failed to decode assembled_response JSON for line with trace={trace}"
+            f"Failed to decode assembled_response JSON for line with trace={trace}"
         )
         return None
-    choices = response_json.get("choices", [])
+    try:
+        choices = response_json.get("choices", [])
+    except AttributeError:
+        logging.warning(
+            f"Root of the assembled_response JSON is not an object for line with trace={trace}"
+        )
+        return None
     if not choices:
         return None
     return choices[0].get("message", {}).get("content")

--- a/tests/test_parse_logs.py
+++ b/tests/test_parse_logs.py
@@ -355,3 +355,65 @@ def test_parse_logs_no_deployment(caplog):
         "Filtered out empty deployment with trace=[('trace_id', '1'), ('core_span_id', '1')]"
         in caplog.text
     )
+
+
+def test_parse_logs_assembled_response_list(caplog):
+    fs = MemoryFileSystem()
+    fs.mkdir("/logs5")
+    fs.mkdir("/parsed_logs5")
+
+    with fs.open(
+        "/logs5/date=2023-11-061699285645-11111111-2222-3333-4444-555555555555.log", "w"
+    ) as f:
+        data_route = {
+            "request": {
+                "protocol": "HTTP/1.1",
+                "method": "POST",
+                "uri": "/v1/custom_route/job",
+                "time": "2023-11-06T01:23:45.678",
+                "body": json.dumps(
+                    {
+                        "some_data": ["https://www.example.com/"],
+                    }
+                ),
+            },
+            "trace": {"trace_id": "1", "core_span_id": "1"},
+            "response": {
+                "status": 200,
+                "body": '["some", "custom"," data"]',
+            },
+            "deployment": "custom_app",
+            "assembled_response": '["some", "custom"," data"]',
+        }
+        json.dump(data_route, f)
+
+    date = pa.scalar(datetime.date(2023, 11, 6), type=pa.date32())
+    parse_logs("memory://logs5/", "memory://parsed_logs5/", date=date)
+
+    result = ds.dataset(
+        "/parsed_logs5/",
+        format="parquet",
+        partitioning=ds.partitioning(
+            schema=pa.schema(
+                [
+                    pa.field("deployment", pa.string()),
+                    pa.field("date", pa.date32()),
+                ]
+            )
+        ),
+        filesystem=fs,
+    ).to_table()
+
+    assert result.column("deployment").to_pylist() == ["custom_app"]
+    assert result.column("date").to_pylist() == [datetime.date(2023, 11, 6)]
+    assert result.column("assembled_response").to_pylist() == [
+        '["some", "custom"," data"]'
+    ]
+    assert result.column("question").to_pylist() == [None]
+    assert result.column("answer").to_pylist() == [None]
+
+    # Check log messages
+    assert (
+        "Root of the assembled_response JSON is not an object for line "
+        "with trace=[('trace_id', '1'), ('core_span_id', '1')]" in caplog.text
+    )


### PR DESCRIPTION
### Description of changes

- do not fail if root element of assembled_response is a list instead of an object

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
