### PR TITLE
fix: use debian instead of alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
-FROM python:3.12-alpine3.20 AS builder
+FROM python:3.12-slim AS builder
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 
-RUN apk update && apk upgrade --no-cache libcrypto3 libssl3
-RUN apk add --no-cache alpine-sdk linux-headers
 RUN pip install --no-cache-dir "poetry==1.8.5"
 RUN python3 -m venv /opt/venv
 
@@ -19,7 +17,7 @@ FROM builder AS test
 RUN poetry install --with test
 RUN poetry run pytest ./tests
 
-FROM python:3.12-alpine3.20
+FROM python:3.12-slim
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1


### PR DESCRIPTION
### Description of changes

Use debian as base image instead of alpine.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
